### PR TITLE
Fix exception where no output filename provided on command line

### DIFF
--- a/zef-xiso-convert/Program.cs
+++ b/zef-xiso-convert/Program.cs
@@ -28,7 +28,7 @@ namespace ZefXISOConvert
                 return;
             }
             string file = args[0];
-            if (args.Length < 2) 
+            if (args.Length == 2) 
             {
                 outfile = args[1];
             }


### PR DESCRIPTION
Fix IndexOutOfRangeException when no output filename specified on command line. This also affected the "drag and drop" functionality.

